### PR TITLE
Move Project and Test project to target .Net 6.0

### DIFF
--- a/.github/workflows/code-cov.yml
+++ b/.github/workflows/code-cov.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET Core SDK 5.0
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: '5.0'
+          dotnet-version: '6.0'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET Core SDK 5.0
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: '5.0'
+          dotnet-version: '6.0'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/TfGM-API-Wrapper-Tests/TfGM-API-Wrapper-Tests.csproj
+++ b/TfGM-API-Wrapper-Tests/TfGM-API-Wrapper-Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>TfGM_API_Wrapper_Tests</RootNamespace>
         <Nullable>enable</Nullable>
 

--- a/TfGM-API-Wrapper/TfGM-API-Wrapper.csproj
+++ b/TfGM-API-Wrapper/TfGM-API-Wrapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>TfGM_API_Wrapper</RootNamespace>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
       <UserSecretsId>68bc7bfb-b0a9-4ae2-b259-a4cd2ecabd4e</UserSecretsId>


### PR DESCRIPTION
This is to avoid problems and vulnerabilities from .Net 5.0 hosted applications.