### PR TITLE
Fix duplicate file deployments by making test project non-publishable.

### DIFF
--- a/TfGM-API-Wrapper-Tests/TfGM-API-Wrapper-Tests.csproj
+++ b/TfGM-API-Wrapper-Tests/TfGM-API-Wrapper-Tests.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>TfGM_API_Wrapper_Tests</RootNamespace>
         <Nullable>enable</Nullable>
-
+        <IsPublishable>false</IsPublishable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 


### PR DESCRIPTION
This should fix errors with duplicate files when running dotnet publish